### PR TITLE
All projects their own CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ include_directories(
     /opt/vc/userland/interface/vcos/pthreads
     /opt/vc/userland/interface/vmcs_host/linux
     /opt/vc/userland/host_applications/linux/libs/bcm_host/include
-    ../libs/ilclient
-    .
+    ${CMAKE_SOURCE_DIR}/libs/glm/
+    ${CMAKE_SOURCE_DIR}/libs/ilclient
 )
 
 set(RPi_LIBS
@@ -42,174 +42,19 @@ set(ILC_LIBS
     openmaxil
 )
 
-link_directories(../libs/ilclient /opt/vc/lib)
+link_directories(${CMAKE_SOURCE_DIR}/libs/ilclient /opt/vc/lib)
 
-# Tutorial 1
-add_executable(../tutorial01_first_screen/tutorial01_first_screen
-    tutorial01_first_screen/tutorial01.cpp
-    common/startScreen.cpp
-)
-target_link_libraries(../tutorial01_first_screen/tutorial01_first_screen
-        ${RPi_LIBS}
-        ${GL_LIBS}
-)
-
-# playground
-add_executable(../playground/playground
-    playground/playground.cpp
-    common/startScreen.cpp
-)
-target_link_libraries(../playground/playground
-        ${RPi_LIBS}
-        ${GL_LIBS}
-)
-
-
-# Tutorial 2
-add_executable(../tutorial02_red_triangle/tutorial02_red_triangle
-    tutorial02_red_triangle/tutorial02.cpp
-    common/startScreen.cpp
-    common/LoadShaders.cpp
-    common/LoadShaders.h
-)
-target_link_libraries(../tutorial02_red_triangle/tutorial02_red_triangle
-        ${RPi_LIBS}
-        ${GL_LIBS}
-)
-
-# Tutorial 2a
-add_executable(../tutorial02a_modelspace/tutorial02a_modelspace
-    tutorial02a_modelspace/tutorial02a.cpp
-    common/startScreen.cpp
-    common/LoadShaders.cpp
-    common/LoadShaders.h
-)
-target_link_libraries(../tutorial02a_modelspace/tutorial02a_modelspace
-        ${RPi_LIBS}
-        ${GL_LIBS}
-)
-
-# Tutorial 3
-add_executable(../tutorial03_matrices/tutorial03_matrices
-    tutorial03_matrices/tutorial03.cpp
-    common/startScreen.cpp
-    common/LoadShaders.cpp
-    common/LoadShaders.h
-)
-target_link_libraries(../tutorial03_matrices/tutorial03_matrices
-        ${RPi_LIBS}
-        ${GL_LIBS}
-)
-
-# Tutorial 4
-add_executable(../tutorial04_coloured_cube/tutorial04_coloured_cube
-    tutorial04_coloured_cube/tutorial04.cpp
-    common/startScreen.cpp
-    common/LoadShaders.cpp
-    common/LoadShaders.h
-)
-target_link_libraries(../tutorial04_coloured_cube/tutorial04_coloured_cube
-        ${RPi_LIBS}
-        ${GL_LIBS}
-)
-
-# Tutorial 5 use .bmp as texture, simplified
-add_executable(../tutorial05_tex/tutorial05_tex
-    tutorial05_tex/tutorial05.cpp
-    common/startScreen.cpp
-    common/LoadShaders.cpp
-    common/LoadShaders.h
-    common/texture.cpp
-    common/texture.h
-)
-target_link_libraries(../tutorial05_tex/tutorial05_tex
-        ${RPi_LIBS}
-        ${GL_LIBS}
-)
-
-# Tutorial 5 use .bmp as texture on 3D cube
-add_executable(../tutorial05_textured_cube/tutorial05_textured_cube
-    tutorial05_textured_cube/tutorial05.cpp
-    common/startScreen.cpp
-    common/LoadShaders.cpp
-    common/LoadShaders.h
-    common/texture.cpp
-    common/texture.h
-)
-target_link_libraries(../tutorial05_textured_cube/tutorial05_textured_cube
-        ${RPi_LIBS}
-        ${GL_LIBS}
-)
-
-
-# Tutorial 5 generate YUV texture
-add_executable(../tutorial05_gen_YUV_tex_disp/tutorial05_gen_YUV_tex_disp
-    tutorial05_gen_YUV_tex_disp/tutorial05.cpp
-    common/camera.cpp
-    common/cameracontrol.cpp
-    common/graphics.cpp
-)
-target_link_libraries(../tutorial05_gen_YUV_tex_disp/tutorial05_gen_YUV_tex_disp
-        ${RPi_LIBS}
-        ${GL_LIBS}
-        ${CAM_LIBS}
-)
-
-# Tutorial 6 use camera as texture Chris Cummings
-add_executable(../tutorial06_tex_cam/tutorial06_tex_cam
-    tutorial06_tex_cam/tutorial06.cpp
-    common/camera.cpp
-    common/cameracontrol.cpp
-    common/graphics.cpp
-    #common/startScreen.cpp
-    #common/LoadShaders.cpp
-    #common/LoadShaders.h
-)
-target_link_libraries(../tutorial06_tex_cam/tutorial06_tex_cam
-        ${RPi_LIBS}
-        ${GL_LIBS}
-        ${CAM_LIBS}
-)
-
-
-# Tutorial encode YUV
-add_executable(../encode/encode
-    encode/encode.c
-)
-
-target_link_libraries(../encode/encode
-        ${RPi_LIBS}
-        ${ILC_LIBS}
-)
-set (CMAKE_C_FLAGS "-DOMX_SKIP64BIT")
-
-# Tutorial encode video using main and header files
-add_executable(../encode_main/encode
-    encode_main/encode.c
-    encode_main/main.c
-)
-
-target_link_libraries(../encode_main/encode
-        ${RPi_LIBS}
-        ${ILC_LIBS}
-)
-set (CMAKE_C_FLAGS "-DOMX_SKIP64BIT")
-
-# Tutorial decode camera YUV video, transform to RGBA, apply matrix in OGL, then transform to YUV and encode to .h264
-add_executable(../encode_OGL/encode
-    encode_OGL/src/encode.c
-    encode_OGL/src/video.c
-    encode_OGL/src/matrix.c
-    encode_OGL/src/ogl.c
-    encode_OGL/main.c
-)
-
-target_link_libraries(../encode_OGL/encode
-        ${RPi_LIBS}
-        ${GL_LIBS}
-        ${CAM_LIBS}
-        ${ILC_LIBS}
-)
-set (CMAKE_C_FLAGS "-DOMX_SKIP64BIT")
-
-# Tutorial 7
+# subdirectories
+add_subdirectory(playground)
+add_subdirectory(tutorial01_first_screen)
+add_subdirectory(tutorial02_red_triangle)
+add_subdirectory(tutorial02a_modelspace)
+add_subdirectory(tutorial03_matrices)
+add_subdirectory(tutorial04_coloured_cube)
+add_subdirectory(tutorial05_tex)
+add_subdirectory(tutorial05_textured_cube)
+add_subdirectory(tutorial05_gen_YUV_tex_disp)
+add_subdirectory(tutorial06_tex_cam)
+add_subdirectory(encode)
+add_subdirectory(encode_main)
+add_subdirectory(encode_OGL)

--- a/encode/CMakeLists.txt
+++ b/encode/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(encode
+    encode.c
+)
+target_link_libraries(encode
+        ${RPi_LIBS}
+        ${ILC_LIBS}
+)
+set (CMAKE_C_FLAGS "-DOMX_SKIP64BIT")

--- a/encode_OGL/CMakeLists.txt
+++ b/encode_OGL/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Tutorial decode camera YUV video, transform to RGBA, apply matrix in OGL, then transform to YUV and encode to .h264
+add_executable(encode_OGL
+    src/encode.c
+    src/video.c
+    src/matrix.c
+    src/ogl.c
+    main.c
+)
+
+target_link_libraries(encode_OGL
+        ${RPi_LIBS}
+        ${GL_LIBS}
+        ${CAM_LIBS}
+        ${ILC_LIBS}
+)
+set (CMAKE_C_FLAGS "-DOMX_SKIP64BIT")

--- a/encode_main/CMakeLists.txt
+++ b/encode_main/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Tutorial encode video using main and header files
+add_executable(encode_main
+    encode.c
+    main.c
+)
+target_link_libraries(encode_main
+        ${RPi_LIBS}
+        ${ILC_LIBS}
+)
+set (CMAKE_C_FLAGS "-DOMX_SKIP64BIT")

--- a/playground/CMakeLists.txt
+++ b/playground/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(playground
+    playground.cpp
+    ../common/startScreen.cpp
+)
+target_link_libraries(playground
+        ${RPi_LIBS}
+        ${GL_LIBS}
+)

--- a/tutorial01_first_screen/CMakeLists.txt
+++ b/tutorial01_first_screen/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(tutorial01_first_screen
+    tutorial01.cpp
+    ../common/startScreen.cpp
+)
+target_link_libraries(tutorial01_first_screen
+        ${RPi_LIBS}
+        ${GL_LIBS}
+)

--- a/tutorial02_red_triangle/CMakeLists.txt
+++ b/tutorial02_red_triangle/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(tutorial02_red_triangle
+    tutorial02.cpp
+    ../common/startScreen.cpp
+    ../common/LoadShaders.cpp
+    ../common/LoadShaders.h
+)
+target_link_libraries(tutorial02_red_triangle
+        ${RPi_LIBS}
+        ${GL_LIBS}
+)
+file(
+	COPY
+	simplefragshader.glsl
+	simplevertshader.glsl
+	DESTINATION ${CMAKE_BINARY_DIR}/tutorial02_red_triangle
+)

--- a/tutorial02a_modelspace/CMakeLists.txt
+++ b/tutorial02a_modelspace/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(tutorial02a_modelspace
+    tutorial02a.cpp
+    ../common/startScreen.cpp
+    ../common/LoadShaders.cpp
+    ../common/LoadShaders.h
+)
+target_link_libraries(tutorial02a_modelspace
+        ${RPi_LIBS}
+        ${GL_LIBS}
+)
+file(
+	COPY
+	simplefragshader.glsl
+	simplevertshader.glsl
+	DESTINATION ${CMAKE_BINARY_DIR}/tutorial02a_modelspace
+)

--- a/tutorial03_matrices/CMakeLists.txt
+++ b/tutorial03_matrices/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(tutorial03_matrices
+    tutorial03.cpp
+    ../common/startScreen.cpp
+    ../common/LoadShaders.cpp
+    ../common/LoadShaders.h
+)
+target_link_libraries(tutorial03_matrices
+        ${RPi_LIBS}
+        ${GL_LIBS}
+)
+file(
+	COPY
+	simplefragshader.glsl
+	simpletransformvertshader.glsl
+	DESTINATION ${CMAKE_BINARY_DIR}/tutorial03_matrices
+)

--- a/tutorial04_coloured_cube/CMakeLists.txt
+++ b/tutorial04_coloured_cube/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(tutorial04_coloured_cube
+    tutorial04.cpp
+    ../common/startScreen.cpp
+    ../common/LoadShaders.cpp
+    ../common/LoadShaders.h
+)
+target_link_libraries(tutorial04_coloured_cube
+        ${RPi_LIBS}
+        ${GL_LIBS}
+)
+file(
+	COPY
+	colourfragshader.glsl
+	transformvertshader.glsl
+	DESTINATION ${CMAKE_BINARY_DIR}/tutorial04_coloured_cube
+)

--- a/tutorial05_gen_YUV_tex_disp/CMakeLists.txt
+++ b/tutorial05_gen_YUV_tex_disp/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_executable(tutorial05_gen_YUV_tex_disp
+    tutorial05.cpp
+    ../common/camera.cpp
+    ../common/cameracontrol.cpp
+    ../common/graphics.cpp
+)
+target_link_libraries(tutorial05_gen_YUV_tex_disp
+        ${RPi_LIBS}
+        ${GL_LIBS}
+        ${CAM_LIBS}
+)
+file(
+	COPY
+	simplefragshader.glsl
+	simplevertshader.glsl
+	yuvfragshader.glsl
+	DESTINATION ${CMAKE_BINARY_DIR}/tutorial05_gen_YUV_tex_disp
+)

--- a/tutorial05_tex/CMakeLists.txt
+++ b/tutorial05_tex/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_executable(tutorial05_tex
+    tutorial05.cpp
+    ../common/startScreen.cpp
+    ../common/LoadShaders.cpp
+    ../common/LoadShaders.h
+    ../common/texture.cpp
+    ../common/texture.h
+)
+target_link_libraries(tutorial05_tex
+        ${RPi_LIBS}
+        ${GL_LIBS}
+)
+file(
+	COPY
+	simplevertshader.glsl
+	texturefragshader.glsl
+	uvtemplate.bmp
+	DESTINATION ${CMAKE_BINARY_DIR}/tutorial05_tex
+)

--- a/tutorial05_textured_cube/CMakeLists.txt
+++ b/tutorial05_textured_cube/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_executable(tutorial05_textured_cube
+    tutorial05.cpp
+    ../common/startScreen.cpp
+    ../common/LoadShaders.cpp
+    ../common/LoadShaders.h
+    ../common/texture.cpp
+    ../common/texture.h
+)
+target_link_libraries(tutorial05_textured_cube
+        ${RPi_LIBS}
+        ${GL_LIBS}
+)
+file(
+	COPY
+	transformvertshader.glsl
+	texturefragshader.glsl
+	uvtemplate.bmp
+	uvtemplate.DDS
+	uvtemplate.tga
+	DESTINATION ${CMAKE_BINARY_DIR}/tutorial05_textured_cube
+)

--- a/tutorial06_tex_cam/CMakeLists.txt
+++ b/tutorial06_tex_cam/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Tutorial 6 use camera as texture Chris Cummings
+add_executable(tutorial06_tex_cam
+    tutorial06.cpp
+    ../common/camera.cpp
+    ../common/cameracontrol.cpp
+    ../common/graphics.cpp
+    #../common/startScreen.cpp
+    #../common/LoadShaders.cpp
+    #../common/LoadShaders.h
+)
+target_link_libraries(tutorial06_tex_cam
+        ${RPi_LIBS}
+        ${GL_LIBS}
+        ${CAM_LIBS}
+)
+file(
+	COPY
+	simplefragshader.glsl
+	simplevertshader.glsl
+	yuvfragshader.glsl
+	DESTINATION ${CMAKE_BINARY_DIR}/tutorial06_tex_cam
+)


### PR DESCRIPTION
This patch changes the build/run process a bit: every project/tutorial has its own CMakeLists.txt. This makes it easier to only build a specific single project. In build, do 'cmake ..' once, then (still in build) cd to the directory you want to build, and do 'make'.

The executable ends up in the build directory. That saves a lot of typing, but also keeps a stricter separation between the build and source directories. Now cmake doesn't have to write to the source directory.

The necessary resources (textures, shaders, audio, config files and what not) are copied to the build directory when you do 'cmake ..'. The originals are safe in the source directories, untouched by the application.

Add 'glm' directory (http://glm.g-truc.net/0.9.4/) to libs and it will be found. Or apt-get install libglm-dev in stead. That will still work.

Also fixed the 'relative path' cmake warning for ilclient.
